### PR TITLE
feat: usememo to prevent re-render of results component

### DIFF
--- a/frontend/src/components/common/QueryPanel.tsx
+++ b/frontend/src/components/common/QueryPanel.tsx
@@ -309,8 +309,8 @@ export const QueryPanel: FC<QueryPanelProps> = ({ id }) => {
         executionLog: {
           ...queryItem.executionLog,
           [executionId]: {
+            ...queryItem.executionLog[executionId],
             id: executionId,
-            userQuestion,
             command: event.target.value,
             timestamp: Date.now(),
           },
@@ -330,9 +330,9 @@ export const QueryPanel: FC<QueryPanelProps> = ({ id }) => {
         executionLog: {
           ...queryItem.executionLog,
           [executionId]: {
+            ...queryItem.executionLog[executionId],
             id: executionId,
             userQuestion: event.target.value,
-            command,
             timestamp: Date.now(),
           },
         },
@@ -667,7 +667,7 @@ export const QueryPanel: FC<QueryPanelProps> = ({ id }) => {
                     <HStack w="100%" justifyContent={"space-between"}>
                       <Text fontSize="sm" color="gray.600" fontWeight="bold">
                         Showing {queryResult.length} results.{" "}
-                        {queryResult.length === 600
+                        {queryResult.length >= 600
                           ? "Results may have been trunctaed because it was too long."
                           : ""}
                       </Text>
@@ -794,6 +794,7 @@ export const QueryPanel: FC<QueryPanelProps> = ({ id }) => {
                 {isLoadingGenerateChart && <Spinner />}
                 {!isLoadingGenerateChart &&
                   chartCode !== undefined &&
+                  // do not pre-render the graph because this causes issues with the chart
                   tabIndex === 1 && (
                     <Flex
                       flexDirection={"column"}

--- a/frontend/src/components/common/ResultTable.tsx
+++ b/frontend/src/components/common/ResultTable.tsx
@@ -10,13 +10,13 @@ import {
   Tr,
   VStack,
 } from "@chakra-ui/react";
-import { FC } from "react";
+import { FC, memo } from "react";
 
 type ResultTableProps = {
   data: DatabaseRow[];
 };
 
-export const ResultTable: FC<ResultTableProps> = ({ data }) => {
+const _ResultTable: FC<ResultTableProps> = ({ data }) => {
   if (data.length === 0) {
     return <Text>No results found.</Text>;
   }
@@ -49,3 +49,6 @@ export const ResultTable: FC<ResultTableProps> = ({ data }) => {
     </VStack>
   );
 };
+
+// https://react.dev/reference/react/memo
+export const ResultTable = memo(_ResultTable);

--- a/frontend/src/node/db/sqlite.ts
+++ b/frontend/src/node/db/sqlite.ts
@@ -58,7 +58,11 @@ export const executeSqliteQuery = async (
   query: string
 ) => {
   const conn = await createConnection(config);
-  return await conn.all<Record<string, string>[]>(query);
+  const rows = await conn.all<Record<string, string>[]>(query);
+  if (rows.length > 600) {
+    return rows.slice(0, 600);
+  }
+  return rows;
 };
 
 const createConnection = async (config: SQLiteConnectionConfig) => {


### PR DESCRIPTION
This prevents re-render of the result panel if the prop is the same. The parent can get re-rendered due to changes in the input or changes in redux, but that shouldn't cause the results table to get re-rendered. The solution for this is to use memo